### PR TITLE
fix: shutdown and entry payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "better-panic"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa9e1d11a268684cbd90ed36370d7577afb6c62d912ddff5c15fc34343e5036"
+dependencies = [
+ "backtrace",
+ "console",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +906,19 @@ checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flexbuffers"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d14128f06405808ce75bfebe11e9b0f9da18719ede6d7bdb1702d6bfe0f7e8"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "num_enum",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1989,6 +2012,7 @@ dependencies = [
 name = "morax-runtime"
 version = "0.1.0"
 dependencies = [
+ "better-panic",
  "error-stack",
  "fastrace",
  "futures",
@@ -2054,7 +2078,9 @@ dependencies = [
 name = "morax-wal-broker"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "error-stack",
+ "flexbuffers",
  "log",
  "mime",
  "morax-meta",
@@ -2062,6 +2088,7 @@ dependencies = [
  "morax-runtime",
  "morax-storage",
  "poem",
+ "serde",
  "serde_json",
  "thiserror",
 ]
@@ -2512,20 +2539,6 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-dependencies = [
- "pollster-macro",
-]
-
-[[package]]
-name = "pollster-macro"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea78f0ef4193055a4b09814ce6bcb572ad1174d6023e2f00a9ea1a798d18d301"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "powerfmt"
@@ -4337,6 +4350,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "wal-tests"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "insta",
  "log",
  "morax-protos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 backon = { version = "1.0", features = ["tokio-sleep"] }
+base64 = { version = "0.22" }
+better-panic = { version = "0.3" }
 build-data = { version = "0.2" }
 byteorder = { version = "1.5" }
 clap = { version = "4.5", features = ["derive"] }
@@ -52,6 +54,7 @@ const_format = { version = "0.2" }
 ctrlc = "3.4"
 error-stack = { version = "0.5" }
 fastrace = { version = "0.7", features = ["enable"] }
+flexbuffers = { version = "2.0" }
 futures = "0.3"
 gix-discover = "0.35"
 insta = { version = "1.38", features = ["json"] }

--- a/api/protos/src/lib.rs
+++ b/api/protos/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate core;
+
 pub mod config;
 pub mod property;
 pub mod rpc;

--- a/crates/kafka-broker/src/network.rs
+++ b/crates/kafka-broker/src/network.rs
@@ -69,10 +69,6 @@ pub async fn start_broker(
                 log::info!("Morax Server is closing");
                 return Ok(());
             }
-            _ = morax_runtime::wait_shutdown() => {
-                log::info!("Morax Server is shutting down");
-                return Ok(());
-            }
             socket = broker_listener.accept() => socket,
         };
 
@@ -98,10 +94,6 @@ async fn process_packet(
         tokio::select! {
              _ = shutdown.wait() => {
                 log::info!("Morax Server is closing");
-                return Ok(());
-            }
-            _ = morax_runtime::wait_shutdown() => {
-                log::info!("Morax Server is shutting down");
                 return Ok(());
             }
             closed = process_packet_one(&mut socket, &remote_addr, &broker) => {

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -26,6 +26,7 @@ version.workspace = true
 test = []
 
 [dependencies]
+better-panic = { workspace = true }
 error-stack = { workspace = true }
 fastrace = { workspace = true }
 futures = { workspace = true }
@@ -38,7 +39,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 
 [dev-dependencies]
-pollster = { version = "0.3", features = ['macro'] }
+pollster = { version = "0.3" }
 
 [lints]
 workspace = true

--- a/crates/runtime/src/wait_group.rs
+++ b/crates/runtime/src/wait_group.rs
@@ -108,7 +108,7 @@ mod test {
 
         for _ in 0..100 {
             let w = wg.clone();
-            let _drop = test_runtime().spawn(async move {
+            test_runtime().spawn(async move {
                 drop(w);
             });
         }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -50,6 +50,7 @@ impl TopicStorage {
         records: Vec<u8>,
     ) -> Result<String, StorageError> {
         let op = self.op()?;
+        // TODO(tisonkun): whether use a sequential number rather than a UUID
         let split_id = uuid::Uuid::new_v4();
         let split_url = format!("{topic_name}/{partition_id}/{split_id}");
         op.write(&split_url, records)

--- a/crates/wal-broker/Cargo.toml
+++ b/crates/wal-broker/Cargo.toml
@@ -23,7 +23,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+base64 = { workspace = true }
 error-stack = { workspace = true }
+flexbuffers = { workspace = true }
 log = { workspace = true }
 mime = { workspace = true }
 morax-meta = { workspace = true }
@@ -31,6 +33,7 @@ morax-protos = { workspace = true }
 morax-runtime = { workspace = true }
 morax-storage = { workspace = true }
 poem = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/tests/wal/Cargo.toml
+++ b/tests/wal/Cargo.toml
@@ -24,6 +24,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+base64 = { workspace = true }
 log = { workspace = true }
 morax-protos = { workspace = true }
 morax-runtime = { workspace = true, features = ["test"] }


### PR DESCRIPTION
We may later find a better way to encode entries on disk (S3). But let's work it around by base64 encoding + flexbuffers now.

The base64 encoding decision is inspired by [Google PubSub's API](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage). That should be convenient yet in good enough performance. 