### PR TITLE
build: enable Fat LTO and codegen-units = 1 in the dist profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,4 +132,5 @@ targets = [
 
 [profile.dist]
 inherits = "release"
-lto = "thin"
+codegen-units = 1
+lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,6 @@ targets = [
 ]
 
 [profile.dist]
-inherits = "release"
 codegen-units = 1
+inherits = "release"
 lto = "fat"


### PR DESCRIPTION
Resolves https://github.com/tisonkun/morax/discussions/22

Enabling Fat LTO + `codegen-units = 1` instead of just Thin LTO leads to the binary size improvement from 20 Mib to 13 Mib.